### PR TITLE
Address Compiler Warnings…

### DIFF
--- a/Classes/SBJson5StreamParser.m
+++ b/Classes/SBJson5StreamParser.m
@@ -33,6 +33,7 @@
 #if !__has_feature(objc_arc)
 #error "This source file must be compiled with ARC enabled!"
 #endif
+#pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
 
 #import "SBJson5StreamParser.h"
 #import "SBJson5StreamTokeniser.h"

--- a/Classes/SBJson5StreamTokeniser.m
+++ b/Classes/SBJson5StreamTokeniser.m
@@ -275,7 +275,7 @@
     }
 }
 
-- (BOOL)isInvalidCodePoint:(long)cp {
+- (BOOL)isInvalidCodePoint:(unsigned long)cp {
     if (cp > 0x10FFFF || SBStringIsSurrogateLowCharacter(cp) || SBStringIsSurrogateHighCharacter(cp)) {
         [self setError:[NSString stringWithFormat:@"Illegal Unicode code point [0x%lX]", cp]];
         return YES;

--- a/Classes/SBJson5StreamWriter.m
+++ b/Classes/SBJson5StreamWriter.m
@@ -33,6 +33,7 @@
 #if !__has_feature(objc_arc)
 #error "This source file must be compiled with ARC enabled!"
 #endif
+#pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
 
 #import "SBJson5StreamWriter.h"
 #import "SBJson5StreamWriterState.h"


### PR DESCRIPTION
Two fixes that suppress compiler warnings. The first about repeated use of weak parameters is straightforward to fix properly. Suppressing the warning in the code is not my preferred answer. As this problem existed in both v4 and in v5, I suspect it isn't considered an important issue. The second fix, in light of the effort to ensure correct behavior, is both easy to fix and preserves the intended comparison behavior of unsigned long to unsigned long.